### PR TITLE
Fix approov xcframework spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/android/a
 Instead, if you want to build for iOS execute from the root of your project:
 
 ```text
-approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/ios/approov.xcframework
+approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/ios/Approov.xcframework
 ```
 > **NOTE:** The approov command is downloading the Approov SDK into `your-project/approov/flutter-httpclient/approov_http_client/ios`
 

--- a/src/echo-chamber-app/README.md
+++ b/src/echo-chamber-app/README.md
@@ -56,7 +56,7 @@ approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/android/a
 Instead, if you want to build for iOS execute from `src/echo-chamber-app` folder:
 
 ```text
-approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/ios/approov.xcframework
+approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/ios/Approov.xcframework
 ```
 > **NOTE:** The approov command is downloading the Approov SDK into the folder `src/echo-chamber-app/approov/flutter-httpclient/approov_http_client/ios`
 


### PR DESCRIPTION
Spelling the name with a lowercase 'a' causes a build failure (or a run-time link failure in the simulator).